### PR TITLE
Performance Optimization via caching

### DIFF
--- a/src/deferredPromise.ts
+++ b/src/deferredPromise.ts
@@ -69,6 +69,11 @@ type Dwaited<T> = {
      * The underlying native `Promise` used for awaiting the deferred `async` chain operation.
      */
     await: BuiltinPromise<T>;
+
+    /**
+     * Returns a deferred string representation of promise's content.
+     */
+    toString: () => string;
 };
 
 /**

--- a/src/deferredPromiseSymbol.ts
+++ b/src/deferredPromiseSymbol.ts
@@ -1,0 +1,3 @@
+const DeferredPromiseSymbol = Symbol("dwait::DeferredPromiseSymbol");
+
+export default DeferredPromiseSymbol;

--- a/src/dwait.ts
+++ b/src/dwait.ts
@@ -21,8 +21,12 @@ function DeferredOperation() {}
  * @returns True if `promise` is a {@link DeferredPromise} otherwise will return false.
  */
 function isDeferredPromise(promise: unknown): boolean {
-  // @ts-expect-error we are sure that this property exists and is callable.
-  return promise[DeferredPromiseSymbol] ? true : false;
+  if (promise === null || promise === undefined) {
+    return false;
+  } else {
+    // @ts-expect-error we are sure that this property exists and is callable.
+    return promise[DeferredPromiseSymbol] ? true : false;
+  }
 }
 
 /**

--- a/src/dwait.ts
+++ b/src/dwait.ts
@@ -101,15 +101,17 @@ function dwaitInternal<T, Y>(
     apply(_, thisArg, args) {
       return dwaitInternal(
         then((target) => {
-          if (!target) {
-            return undefined as Awaited<T>;
-          } else if (typeof target === "string") {
-            return target as Awaited<T>;
+          if (typeof target !== "function") {
+            console.log(target, thisArg, args);
+            const numberOfArguments = args?.length || 0;
+            throw new TypeError(
+              `${target} is not a function, unexpected call to ${target} passing (${
+                args.join(", ") || "nothing"
+              }) as arguments.`
+            );
           } else if (lhs?.value !== undefined) {
-            // @ts-expect-error this is just deferred actions of the user, and user has to make sure target is a valid function
             return Reflect.apply(target, lhs.value, args);
           } else {
-            // @ts-expect-error this is just deferred actions of the user, and user has to make sure target is a valid function
             return Reflect.apply(target, thisArg, args);
           }
         }),

--- a/src/dwait.ts
+++ b/src/dwait.ts
@@ -22,7 +22,7 @@ function DeferredOperation() {}
  */
 function isDeferredPromise(promise: unknown): boolean {
   // @ts-expect-error we are sure that this property exists and is callable.
-  return promise[DeferredPromiseSymbol];
+  return promise[DeferredPromiseSymbol] ? true : false;
 }
 
 /**

--- a/src/dwait.ts
+++ b/src/dwait.ts
@@ -76,11 +76,13 @@ function dwaitInternal<T, Y>(
       } else {
         return dwaitInternal(
           then((target) => {
-            if (target !== undefined) {
+            if (target === undefined || target === null) {
+              throw new RangeError(
+                `Property ${prop} does not exists on ${target}.`
+              );
+            } else {
               // @ts-expect-error this is just deferred actions of the user, and user has to make sure target property is a valid value
               return target[prop];
-            } else {
-              return null;
             }
           }),
           result

--- a/tests/dwait.spec.ts
+++ b/tests/dwait.spec.ts
@@ -169,6 +169,33 @@ describe("dwait Tests", () => {
       new RangeError(`Property ${NUMBER} does not exists on undefined.`)
     );
   });
+
+  test("should throw on calling null or undefined DeferredPromise", async () => {
+    const nullPromise = dwait(null);
+    const undefinedPromise = dwait(undefined);
+    // @ts-expect-error Is is necessary for test to call it even tho it will throw
+    await expect(nullPromise()).rejects.toEqual(
+      new TypeError(
+        `null is not a function, unexpected call to null passing (nothing) as arguments.`
+      )
+    );
+    // @ts-expect-error Is is necessary for test to call it even tho it will throw
+    await expect(undefinedPromise()).rejects.toEqual(
+      new TypeError(
+        `undefined is not a function, unexpected call to undefined passing (nothing) as arguments.`
+      )
+    );
+  });
+
+  test("should throw on calling strings wrapped in DeferredPromise", async () => {
+    const strPromise = dwait(OK);
+    // @ts-expect-error Is is necessary for test to call it even tho it will throw
+    await expect(strPromise()).rejects.toEqual(
+      new TypeError(
+        `OK is not a function, unexpected call to OK passing (nothing) as arguments.`
+      )
+    );
+  });
 });
 
 describe("isDeferredPromise Tests", () => {

--- a/tests/dwait.spec.ts
+++ b/tests/dwait.spec.ts
@@ -145,6 +145,12 @@ describe("dwait Tests", () => {
     await expect(dwaitPromise.foo.await).resolves.toEqual(OKB);
   });
 
+  test("shouldn't defer an already deferred promise", async () => {
+    const dwaitPromise1 = dwait(resolveClass());
+    const dwaitPromise2 = dwait(dwaitPromise1);
+    expect(dwaitPromise1).toBe(dwaitPromise2);
+  });
+
   test("should return the same DeferredPromise as long as a reference of that DeferredPromise exists on the heap", async () => {
     const dwaitPromise1 = dwait(resolveClass());
     const dwaitPromise2 = dwait(resolveClass());

--- a/tests/dwait.spec.ts
+++ b/tests/dwait.spec.ts
@@ -153,9 +153,10 @@ describe("dwait Tests", () => {
   });
 
   test("should return the same DeferredPromise as long as a reference of that DeferredPromise exists on the heap", async () => {
-    const dwaitPromise1 = dwait(resolveClass());
-    const dwaitPromise2 = dwait(resolveClass());
-    expect(dwaitPromise1).toBe(dwaitPromise1);
+    const klass = resolveClass();
+    const dwaitPromise1 = dwait(klass);
+    const dwaitPromise2 = dwait(klass);
+    expect(dwaitPromise1).toBe(dwaitPromise2);
   });
 
   test("should throw on accessing properties on null or undefined deferred operations", async () => {

--- a/tests/dwait.spec.ts
+++ b/tests/dwait.spec.ts
@@ -1,8 +1,9 @@
-import dwait from "../src/dwait";
+import dwait, { isDeferredPromise } from "../src/dwait";
 
 const OK = "OK";
 const ERROR = "ERROR";
 const NUMBER = 12345;
+const OBJECT = {};
 const OKA = `${OK}A`;
 const OKB = `${OK}B`;
 const MATCH_OK = /^OK/g;
@@ -155,5 +156,69 @@ describe("dwait Tests", () => {
     const dwaitPromise1 = dwait(resolveClass());
     const dwaitPromise2 = dwait(resolveClass());
     expect(dwaitPromise1).toBe(dwaitPromise1);
+  });
+});
+
+describe("isDeferredPromise Tests", () => {
+  const resolveMock: () => Promise<string> = jest.fn().mockResolvedValue(OK);
+
+  test("should return false on normal promises", async () => {
+    const target = resolveMock();
+    expect(isDeferredPromise(target)).toBe(false);
+  });
+
+  test("should return false on normal objects", async () => {
+    const target = OBJECT;
+    expect(isDeferredPromise(target)).toBe(false);
+  });
+
+  test("should return false on normal numbers", async () => {
+    const target = NUMBER;
+    expect(isDeferredPromise(target)).toBe(false);
+  });
+
+  test("should return false on normal strings", async () => {
+    const target = OK;
+    expect(isDeferredPromise(target)).toBe(false);
+  });
+
+  test("should return false on normal null values", async () => {
+    const target = null;
+    expect(isDeferredPromise(target)).toBe(false);
+  });
+
+  test("should return false on normal undefined values", async () => {
+    const target = undefined;
+    expect(isDeferredPromise(target)).toBe(false);
+  });
+
+  test("should return true on deferred promises", async () => {
+    const target = dwait(resolveMock());
+    expect(isDeferredPromise(target)).toBe(true);
+  });
+
+  test("should return true on deferred objects", async () => {
+    const target = dwait(OBJECT);
+    expect(isDeferredPromise(target)).toBe(true);
+  });
+
+  test("should return true on deferred numbers", async () => {
+    const target = dwait(NUMBER);
+    expect(isDeferredPromise(target)).toBe(true);
+  });
+
+  test("should return true on deferred strings", async () => {
+    const target = dwait(OK);
+    expect(isDeferredPromise(target)).toBe(true);
+  });
+
+  test("should return true on deferred null values", async () => {
+    const target = dwait(null);
+    expect(isDeferredPromise(target)).toBe(true);
+  });
+
+  test("should return true on deferred undefined values", async () => {
+    const target = dwait(undefined);
+    expect(isDeferredPromise(target)).toBe(true);
   });
 });

--- a/tests/dwait.spec.ts
+++ b/tests/dwait.spec.ts
@@ -157,6 +157,17 @@ describe("dwait Tests", () => {
     const dwaitPromise2 = dwait(resolveClass());
     expect(dwaitPromise1).toBe(dwaitPromise1);
   });
+
+  test("should throw on accessing properties on null or undefined deferred operations", async () => {
+    const nullPromise = dwait(null)[NUMBER];
+    const undefinedPromise = dwait(undefined)[NUMBER];
+    await expect(nullPromise).rejects.toEqual(
+      new RangeError(`Property ${NUMBER} does not exists on null.`)
+    );
+    await expect(undefinedPromise).rejects.toEqual(
+      new RangeError(`Property ${NUMBER} does not exists on undefined.`)
+    );
+  });
 });
 
 describe("isDeferredPromise Tests", () => {

--- a/tests/dwait.spec.ts
+++ b/tests/dwait.spec.ts
@@ -144,4 +144,10 @@ describe("dwait Tests", () => {
     }
     await expect(dwaitPromise.foo.await).resolves.toEqual(OKB);
   });
+
+  test("should return the same DeferredPromise as long as a reference of that DeferredPromise exists on the heap", async () => {
+    const dwaitPromise1 = dwait(resolveClass());
+    const dwaitPromise2 = dwait(resolveClass());
+    expect(dwaitPromise1).toBe(dwaitPromise1);
+  });
 });


### PR DESCRIPTION
This PR introduces the `WeakReference` caching to the `dwait` interface which reduces the redundant object proxying.